### PR TITLE
#20 Fix: Prevent AsciidoctorJ diagram generation in project root directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
-        <asciidoctorj.version>2.5.7</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.2.8</asciidoctorj.diagram.version>
+        <asciidoctorj.version>2.5.13</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.3.2</asciidoctorj.diagram.version>
         <jackson.version>2.19.2</jackson.version>
         <maven.plugin.tools.version>3.15.1</maven.plugin.tools.version>
     </properties>

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
@@ -169,7 +169,10 @@ public class RenderMojo extends AbstractAsciiDocMojo {
         
         if (enableDiagrams) {
             allAttributes.put("diagram-format", diagramFormat);
-            allAttributes.put("imagesoutdir", new File(workDirectory, "images").getAbsolutePath());
+            // Set imagesoutdir to workDirectory to avoid generating diagrams in project root
+            File imagesOutDir = new File(workDirectory, "images");
+            imagesOutDir.mkdirs();
+            allAttributes.put("imagesoutdir", imagesOutDir.getAbsolutePath());
             allAttributes.put("diagram-cachedir", new File(workDirectory, "diagram-cache").getAbsolutePath());
         }
 
@@ -268,7 +271,19 @@ public class RenderMojo extends AbstractAsciiDocMojo {
         String content = Files.readString(adocFile);
         
         // Use AsciidoctorJ to parse the document
+        Map<String, Object> allAttributes = new HashMap<>(attributes);
+        
+        // Prevent diagram generation in project root (same as in convertAsciiDocToHtml)
+        if (enableDiagrams) {
+            File imagesOutDir = new File(workDirectory, "images");
+            imagesOutDir.mkdirs();
+            allAttributes.put("imagesoutdir", imagesOutDir.getAbsolutePath());
+            allAttributes.put("diagram-format", diagramFormat);
+            allAttributes.put("diagram-cachedir", new File(workDirectory, "diagram-cache").getAbsolutePath());
+        }
+        
         Attributes documentAttributes = Attributes.builder()
+                .attributes(allAttributes)
                 .skipFrontMatter(true)
                 .build();
                 

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
@@ -154,7 +154,15 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
         String content = Files.readString(adocFile);
         
         // Use AsciidoctorJ to parse the document
+        Map<String, Object> allAttributes = new HashMap<>();
+        
+        // Use temp directory for diagrams during validation to avoid polluting project
+        File tempImagesDir = new File(System.getProperty("java.io.tmpdir"), "asciidoc-validate-images");
+        tempImagesDir.mkdirs();
+        allAttributes.put("imagesoutdir", tempImagesDir.getAbsolutePath());
+        
         Attributes documentAttributes = Attributes.builder()
+                .attributes(allAttributes)
                 .skipFrontMatter(true)
                 .build();
                 

--- a/src/test/resources/functional/render/inline-template-complex-test/expected.html
+++ b/src/test/resources/functional/render/inline-template-complex-test/expected.html
@@ -7,6 +7,7 @@
 <body>
     <header>
         <h1>Complex Template Test Document</h1>
+        <p class="version">Version: 2.0</p>
     </header>
 
     <main>


### PR DESCRIPTION
## Summary
- Configure diagram output to use target directory instead of project root
- Fix both RenderMojo and ValidateMojo diagram paths