### PR TITLE
#22 Update asciidoc-linter to version 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>com.dataliquid</groupId>
             <artifactId>asciidoc-linter</artifactId>
-            <version>0.2.0</version>
+            <version>0.4.0</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
@@ -12,7 +12,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.dataliquid.asciidoc.linter.Linter;
 import com.dataliquid.asciidoc.linter.config.LinterConfiguration;
-import com.dataliquid.asciidoc.linter.config.Severity;
+import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.loader.ConfigurationLoader;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;

--- a/src/test/java/com/dataliquid/maven/asciidoc/mojo/LinterMojoTest.java
+++ b/src/test/java/com/dataliquid/maven/asciidoc/mojo/LinterMojoTest.java
@@ -96,7 +96,7 @@ class LinterMojoTest extends AbstractMojoTest<LinterMojo> {
         verify(mockLog).info(eq("  Warnings: 0"));
         
         // Verify error message was logged
-        verify(mockLog).error(eq("[document.adoc:4] ERROR: Attribute 'keywords' is too long: actual 'This is a very long keywords list that exceeds the maximum allowed' (66 characters), expected maximum 20 characters"));
+        verify(mockLog).error(eq("[document.adoc:2] ERROR: Attribute 'keywords' is too long: actual 'This is a very long keywords list that exceeds the maximum allowed' (66 characters), expected maximum 20 characters"));
     }
     
     @Test


### PR DESCRIPTION
## Summary
- Update asciidoc-linter dependency from 0.2.0 to 0.4.0
- Fix breaking change: Severity class moved to different package
- Update test for corrected line number reporting