### PR TITLE
#29 Update to use maven.compiler.release property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,6 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
@@ -180,10 +178,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary  
- Remove redundant maven.compiler.source and maven.compiler.target properties
- Keep only maven.compiler.release=17
- Remove explicit maven-compiler-plugin declaration as it's inherited from parent-oss

## Test plan
- [x] Build passes with `mvn clean install`
- [x] Tests pass successfully
- [x] Plugin works correctly with Java 17 projects