### PR TITLE
Fix AsciidoctorJ 3.0.0 compatibility

### DIFF
--- a/.asciidoctor/diagram/diag-plantuml-md5-dba62210869b89d73536552777eec82e.png.cache
+++ b/.asciidoctor/diagram/diag-plantuml-md5-dba62210869b89d73536552777eec82e.png.cache
@@ -1,0 +1,1 @@
+{"checksum":"plantuml-md5-dba62210869b89d73536552777eec82e","options":{"size_limit":"4096"},"width":108,"height":127}

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
-        <asciidoctorj.version>2.5.13</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.3.2</asciidoctorj.diagram.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
+        <asciidoctorj.diagram.version>3.0.1</asciidoctorj.diagram.version>
         <jackson.version>2.19.2</jackson.version>
         <maven.plugin.tools.version>3.15.1</maven.plugin.tools.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,12 @@
             <version>${asciidoctorj.diagram.version}</version>
         </dependency>
         
-        <!-- PlantUML processor for AsciidoctorJ -->
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram-plantuml</artifactId>
             <version>${asciidoctorj.diagram.plantuml.version}</version>
         </dependency>
         
-        <!-- Ditaa processor for AsciidoctorJ -->
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram-ditaamini</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,18 @@
             <version>${asciidoctorj.diagram.version}</version>
         </dependency>
         
-        <!-- PlantUML for diagram generation -->
+        <!-- PlantUML processor for AsciidoctorJ -->
         <dependency>
-            <groupId>net.sourceforge.plantuml</groupId>
-            <artifactId>plantuml</artifactId>
-            <version>1.2024.8</version>
-            <scope>test</scope>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+            <version>1.2025.3</version>
+        </dependency>
+        
+        <!-- Ditaa processor for AsciidoctorJ -->
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-diagram-ditaamini</artifactId>
+            <version>1.0.3</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <maven.version>3.9.11</maven.version>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>3.0.1</asciidoctorj.diagram.version>
+        <asciidoctorj.diagram.plantuml.version>1.2025.3</asciidoctorj.diagram.plantuml.version>
+        <asciidoctorj.diagram.ditaamini.version>1.0.3</asciidoctorj.diagram.ditaamini.version>
         <jackson.version>2.19.2</jackson.version>
         <maven.plugin.tools.version>3.15.1</maven.plugin.tools.version>
     </properties>
@@ -74,14 +76,14 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram-plantuml</artifactId>
-            <version>1.2025.3</version>
+            <version>${asciidoctorj.diagram.plantuml.version}</version>
         </dependency>
         
         <!-- Ditaa processor for AsciidoctorJ -->
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram-ditaamini</artifactId>
-            <version>1.0.3</version>
+            <version>${asciidoctorj.diagram.ditaamini.version}</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
             <version>${asciidoctorj.diagram.version}</version>
         </dependency>
         
+        <!-- PlantUML for diagram generation -->
+        <dependency>
+            <groupId>net.sourceforge.plantuml</groupId>
+            <artifactId>plantuml</artifactId>
+            <version>1.2024.8</version>
+            <scope>test</scope>
+        </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
@@ -14,6 +14,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
@@ -179,7 +180,11 @@ public class RenderMojo extends AbstractAsciiDocMojo {
         }
 
         // Enable AsciidoctorJ's built-in front matter handling
-        Attributes documentAttributes = Attributes.builder().attributes(allAttributes).skipFrontMatter(true).build();
+        AttributesBuilder attrBuilder = Attributes.builder();
+        for (Map.Entry<String, Object> entry : allAttributes.entrySet()) {
+            attrBuilder.attribute(entry.getKey(), entry.getValue());
+        }
+        Attributes documentAttributes = attrBuilder.skipFrontMatter(true).build();
 
         OptionsBuilder optionsBuilder = Options
                 .builder()
@@ -283,7 +288,11 @@ public class RenderMojo extends AbstractAsciiDocMojo {
             allAttributes.put("diagram-cachedir", new File(workDirectory, "diagram-cache").getAbsolutePath());
         }
 
-        Attributes documentAttributes = Attributes.builder().attributes(allAttributes).skipFrontMatter(true).build();
+        AttributesBuilder attrBuilder2 = Attributes.builder();
+        for (Map.Entry<String, Object> entry : allAttributes.entrySet()) {
+            attrBuilder2.attribute(entry.getKey(), entry.getValue());
+        }
+        Attributes documentAttributes = attrBuilder2.skipFrontMatter(true).build();
 
         Options options = Options.builder().safe(SafeMode.UNSAFE).attributes(documentAttributes).build();
 

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
@@ -179,7 +179,7 @@ public class RenderMojo extends AbstractAsciiDocMojo {
             allAttributes.put("diagram-cachedir", new File(workDirectory, "diagram-cache").getAbsolutePath());
         }
 
-        // Enable AsciidoctorJ's built-in front matter handling
+        // Build document attributes
         AttributesBuilder attrBuilder = Attributes.builder();
         for (Map.Entry<String, Object> entry : allAttributes.entrySet()) {
             attrBuilder.attribute(entry.getKey(), entry.getValue());

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
@@ -179,11 +179,11 @@ public class RenderMojo extends AbstractAsciiDocMojo {
             allAttributes.put("diagram-cachedir", new File(workDirectory, "diagram-cache").getAbsolutePath());
         }
 
-        // Build document attributes
         AttributesBuilder attrBuilder = Attributes.builder();
         for (Map.Entry<String, Object> entry : allAttributes.entrySet()) {
             attrBuilder.attribute(entry.getKey(), entry.getValue());
         }
+        // Enable AsciidoctorJ's built-in front matter handling
         Attributes documentAttributes = attrBuilder.skipFrontMatter(true).build();
 
         OptionsBuilder optionsBuilder = Options

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
@@ -17,6 +17,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.Document;
@@ -160,7 +161,11 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
         tempImagesDir.mkdirs();
         allAttributes.put("imagesoutdir", tempImagesDir.getAbsolutePath());
 
-        Attributes documentAttributes = Attributes.builder().attributes(allAttributes).skipFrontMatter(true).build();
+        AttributesBuilder attrBuilder = Attributes.builder();
+        for (Map.Entry<String, Object> entry : allAttributes.entrySet()) {
+            attrBuilder.attribute(entry.getKey(), entry.getValue());
+        }
+        Attributes documentAttributes = attrBuilder.skipFrontMatter(true).build();
 
         Options options = Options.builder().safe(SafeMode.UNSAFE).attributes(documentAttributes).build();
 


### PR DESCRIPTION
## Summary
- Fixed breaking changes in AsciidoctorJ 3.0.0 API
- Updated AttributesBuilder usage to use attribute(key, value) method instead of deprecated attributes(Map) method  
- Upgraded AsciidoctorJ from 2.5.13 to 3.0.0
- Upgraded AsciidoctorJ-diagram from 2.3.2 to 3.0.1
- Added diagram processor dependencies:
  - asciidoctorj-diagram-plantuml (1.2025.3)
  - asciidoctorj-diagram-ditaamini (1.0.3)

## Test plan
- [x] Build passes with `mvn clean compile`
- [x] ALL 90 tests pass successfully locally
- [x] ValidateMojoTest passes
- [x] LinterMojoTest passes
- [x] RenderMojoTest passes (including all diagram tests)
- [x] Diagram generation (PlantUML/Ditaa) works correctly