### PR TITLE
#34 Replace maven.compiler.release with source/target properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
     </licenses>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.11</maven.version>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>


### PR DESCRIPTION
## Summary
- Replaced maven.compiler.release property with maven.compiler.source and maven.compiler.target properties due to a known bug

## Test plan
- [x] CI build passes
- [x] Project compiles successfully with mvn clean compile
- [x] All tests pass