### PR TITLE
#45 Add YAML AsciiDoc linting support

### DIFF
--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
@@ -23,6 +23,10 @@ import com.dataliquid.asciidoc.linter.config.output.SummaryConfig;
 import com.dataliquid.asciidoc.linter.config.output.HighlightStyle;
 import com.dataliquid.maven.asciidoc.report.MavenReportFormatter;
 import com.dataliquid.maven.asciidoc.report.MavenLogWriter;
+import com.dataliquid.maven.asciidoc.yaml.YamlAsciiDocProcessor;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 
 /**
  * Goal to lint AsciiDoc files using asciidoc-linter.
@@ -85,12 +89,20 @@ public class LinterMojo extends AbstractAsciiDocMojo {
 
             // Lint each file
             for (Path file : adocFiles) {
-                getLog().info("Linting: " + file);
-                ValidationResult result = linter.validateFile(file, linterConfiguration);
+                String fileName = file.getFileName().toString().toLowerCase();
 
-                // Process results with enhanced formatter
-                if (!result.getMessages().isEmpty()) {
-                    formatter.format(result);
+                if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) {
+                    // Process YAML files with embedded AsciiDoc
+                    lintYamlFile(file, linter, linterConfiguration, formatter);
+                } else {
+                    // Process regular AsciiDoc files
+                    getLog().info("Linting: " + file);
+                    ValidationResult result = linter.validateFile(file, linterConfiguration);
+
+                    // Process results with enhanced formatter
+                    if (!result.getMessages().isEmpty()) {
+                        formatter.format(result);
+                    }
                 }
             }
 
@@ -133,5 +145,46 @@ public class LinterMojo extends AbstractAsciiDocMojo {
                         .build())
                 .summary(summaryConfig)
                 .build();
+    }
+
+    /**
+     * Lint a YAML file containing !asciidoc tags
+     */
+    private void lintYamlFile(Path yamlFile, Linter linter, LinterConfiguration linterConfiguration,
+            MavenReportFormatter formatter) throws IOException {
+        getLog().info("Linting YAML file: " + yamlFile);
+
+        // Create YamlAsciiDocProcessor instance (without Asciidoctor for extraction
+        // only)
+        YamlAsciiDocProcessor yamlProcessor = new YamlAsciiDocProcessor(null, null, getLog());
+
+        // Extract AsciiDoc content from YAML
+        List<YamlAsciiDocProcessor.ExtractedContent> extractedContents = yamlProcessor.extractAsciiDocContent(yamlFile);
+
+        if (extractedContents.isEmpty()) {
+            getLog().debug("No !asciidoc tags found in: " + yamlFile);
+            return;
+        }
+
+        getLog().info("Found " + extractedContents.size() + " AsciiDoc content blocks in YAML file");
+
+        // Lint each extracted content
+        for (YamlAsciiDocProcessor.ExtractedContent extracted : extractedContents) {
+            getLog().debug("Linting YAML path: " + extracted.getYamlPath());
+
+            // Validate the content string
+            ValidationResult result = linter.validateContent(extracted.getContent(), linterConfiguration);
+
+            // If there are validation messages, log them with YAML context
+            if (!result.getMessages().isEmpty()) {
+                // Log the YAML path context for this content block
+                getLog().info("");
+                getLog().info("YAML file: " + yamlFile);
+                getLog().info("YAML path: " + extracted.getYamlPath());
+
+                // Format and display the validation results
+                formatter.format(result);
+            }
+        }
     }
 }

--- a/src/test/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessorTest.java
+++ b/src/test/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessorTest.java
@@ -1,0 +1,182 @@
+package com.dataliquid.maven.asciidoc.yaml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class YamlAsciiDocProcessorTest {
+
+    private YamlAsciiDocProcessor processor;
+    private Log mockLog;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        mockLog = mock(Log.class);
+        // For extraction, we don't need Asciidoctor, so we can pass null
+        processor = new YamlAsciiDocProcessor(null, null, mockLog);
+    }
+
+    @Test
+    void shouldExtractSingleAsciiDocContent() throws IOException {
+        // given
+        String yaml = """
+                title: Test Document
+                content: !asciidoc |
+                  = My Document
+
+                  This is a test document.
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertEquals(1, extracted.size());
+        assertEquals("content", extracted.get(0).getYamlPath());
+        assertTrue(extracted.get(0).getContent().contains("= My Document"));
+    }
+
+    @Test
+    void shouldExtractMultipleAsciiDocContents() throws IOException {
+        // given
+        String yaml = """
+                sections:
+                  - name: Introduction
+                    text: !asciidoc |
+                      == Introduction
+
+                      This is the intro.
+                  - name: Conclusion
+                    text: !asciidoc |
+                      == Conclusion
+
+                      This is the conclusion.
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertEquals(2, extracted.size());
+        assertEquals("sections[0].text", extracted.get(0).getYamlPath());
+        assertEquals("sections[1].text", extracted.get(1).getYamlPath());
+        assertTrue(extracted.get(0).getContent().contains("== Introduction"));
+        assertTrue(extracted.get(1).getContent().contains("== Conclusion"));
+    }
+
+    @Test
+    void shouldExtractNestedAsciiDocContent() throws IOException {
+        // given
+        String yaml = """
+                api:
+                  documentation:
+                    overview: !asciidoc |
+                      = API Overview
+
+                      REST API documentation.
+                    endpoints:
+                      users:
+                        description: !asciidoc |
+                          == User Endpoints
+
+                          User management endpoints.
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertEquals(2, extracted.size());
+        assertEquals("api.documentation.overview", extracted.get(0).getYamlPath());
+        assertEquals("api.documentation.endpoints.users.description", extracted.get(1).getYamlPath());
+    }
+
+    @Test
+    void shouldHandleYamlWithoutAsciiDocTags() throws IOException {
+        // given
+        String yaml = """
+                title: Regular YAML
+                description: No AsciiDoc content here
+                items:
+                  - name: Item 1
+                  - name: Item 2
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertTrue(extracted.isEmpty());
+    }
+
+    @Test
+    void shouldHandleComplexYamlPaths() throws IOException {
+        // given
+        String yaml = """
+                documentation:
+                  chapters:
+                    - title: Chapter 1
+                      sections:
+                        - content: !asciidoc |
+                            == Section 1.1
+                        - content: !asciidoc |
+                            == Section 1.2
+                    - title: Chapter 2
+                      sections:
+                        - content: !asciidoc |
+                            == Section 2.1
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertEquals(3, extracted.size());
+        assertEquals("documentation.chapters[0].sections[0].content", extracted.get(0).getYamlPath());
+        assertEquals("documentation.chapters[0].sections[1].content", extracted.get(1).getYamlPath());
+        assertEquals("documentation.chapters[1].sections[0].content", extracted.get(2).getYamlPath());
+    }
+
+    @Test
+    void shouldHandleEmptyAsciiDocContent() throws IOException {
+        // given
+        String yaml = """
+                content: !asciidoc |
+                """;
+        Path yamlFile = tempDir.resolve("test.yaml");
+        Files.writeString(yamlFile, yaml);
+
+        // when
+        List<YamlAsciiDocProcessor.ExtractedContent> extracted = processor.extractAsciiDocContent(yamlFile);
+
+        // then
+        assertEquals(1, extracted.size());
+        assertEquals("content", extracted.get(0).getYamlPath());
+        assertNotNull(extracted.get(0).getContent());
+        assertTrue(extracted.get(0).getContent().isEmpty() || extracted.get(0).getContent().isBlank());
+    }
+}

--- a/src/test/resources/functional/lint/yaml-lint-test/document.yaml
+++ b/src/test/resources/functional/lint/yaml-lint-test/document.yaml
@@ -1,0 +1,38 @@
+title: API Documentation
+author: Test Author
+sections:
+  - name: Introduction
+    content: !asciidoc |
+      = Getting Started
+      :author: Test Author
+      :doctype: article
+
+      This is a simple introduction to our API.
+
+      == Overview
+
+      Our API provides the following features:
+
+      * Feature 1
+      * Feature 2
+      * Feature 3
+
+  - name: Authentication
+    content: !asciidoc |
+      = Authentication Guide
+      :author: Security Team
+
+      You need to authenticate using OAuth 2.0.
+
+      == Getting Tokens
+
+      Request tokens from our endpoint.
+
+appendix:
+  glossary: !asciidoc |
+    = Glossary
+    :author: Documentation Team
+
+    API:: Application Programming Interface
+    OAuth:: Open Authorization
+    REST:: Representational State Transfer

--- a/src/test/resources/functional/lint/yaml-lint-test/linter-rules.yaml
+++ b/src/test/resources/functional/lint/yaml-lint-test/linter-rules.yaml
@@ -1,0 +1,7 @@
+document:
+  metadata:
+    attributes:
+      - name: doctype
+        required: false
+        severity: info
+        maxLength: 50

--- a/src/test/resources/functional/lint/yaml-with-violations/content.yaml
+++ b/src/test/resources/functional/lint/yaml-with-violations/content.yaml
@@ -1,0 +1,29 @@
+metadata:
+  version: "1.0"
+
+documentation:
+  intro: !asciidoc |
+    = Introduction Document
+
+    This document is missing required attributes like author and keywords.
+
+    == Section One
+
+    Some content here.
+
+api:
+  endpoints:
+    - path: /users
+      description: !asciidoc |
+        = User API Documentation
+        :description: User management endpoints
+
+        Missing author and keywords attributes.
+
+    - path: /posts
+      description: !asciidoc |
+        = Posts API
+        :author: Test Author
+        :keywords: api, posts
+
+        This one has all required attributes.

--- a/src/test/resources/functional/lint/yaml-with-violations/linter-rules.yaml
+++ b/src/test/resources/functional/lint/yaml-with-violations/linter-rules.yaml
@@ -1,0 +1,9 @@
+document:
+  metadata:
+    attributes:
+      - name: author
+        required: true
+        severity: error
+      - name: keywords
+        required: true
+        severity: error


### PR DESCRIPTION
## Summary

- Extended `YamlAsciiDocProcessor` with content extraction method for linting
- Modified `LinterMojo` to detect and process YAML files with `!asciidoc` tags
- Added comprehensive test coverage for YAML linting scenarios

## Implementation

This PR extends the linter mojo to support YAML files containing AsciiDoc content (via `!asciidoc` tags), similar to the render mojo implementation from #43. 

Key changes:
- Extract AsciiDoc content from YAML without rendering
- Validate each extracted block with the linter
- Include YAML path context in error messages (e.g., `sections[2].content`)
- Full test coverage with success and error scenarios

## Test Plan

- [x] Unit tests for `YamlAsciiDocProcessor.extractAsciiDocContent()`
- [x] Integration tests for YAML linting without errors
- [x] Integration tests for YAML linting with validation errors
- [x] Verify YAML path context appears in error messages
- [x] Test mixed `.adoc` and `.yaml` file processing
- [x] All existing tests still pass

Closes #45