### PR TITLE
#48 Support pass-through of unknown YAML tags

### DIFF
--- a/src/main/java/com/dataliquid/maven/asciidoc/yaml/AsciiDocTag.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/yaml/AsciiDocTag.java
@@ -1,11 +1,14 @@
 package com.dataliquid.maven.asciidoc.yaml;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Represent;
+import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * Custom YAML constructor for handling !asciidoc tags
@@ -17,6 +20,8 @@ public class AsciiDocTag extends Constructor {
     public AsciiDocTag() {
         super(new LoaderOptions());
         this.yamlConstructors.put(ASCIIDOC_TAG, new ConstructAsciiDoc());
+        // Always register fallback constructor for unknown tags
+        this.yamlMultiConstructors.put("", new ConstructUnknownTag());
     }
 
     private class ConstructAsciiDoc extends AbstractConstruct {
@@ -26,6 +31,24 @@ public class AsciiDocTag extends Constructor {
             String value = scalarNode.getValue();
             // Wrap the content in a marker object so we can identify it during traversal
             return new AsciiDocContent(value);
+        }
+    }
+
+    /**
+     * Fallback constructor for unknown tags when preserveUnknownTags is enabled.
+     * Wraps unknown tags in TaggedValue to preserve tag information.
+     */
+    private class ConstructUnknownTag extends AbstractConstruct {
+        @Override
+        public Object construct(Node node) {
+            if (node instanceof ScalarNode) {
+                ScalarNode scalarNode = (ScalarNode) node;
+                String tag = scalarNode.getTag().getValue();
+                String value = scalarNode.getValue();
+                return new TaggedValue(tag, value);
+            }
+            // For non-scalar nodes, use the default constructor
+            return constructObject(node);
         }
     }
 
@@ -55,6 +78,46 @@ public class AsciiDocTag extends Constructor {
         @Override
         public String toString() {
             return rendered != null ? rendered : content;
+        }
+    }
+
+    /**
+     * Wrapper for unknown YAML tags to preserve tag information in output
+     */
+    public static class TaggedValue {
+        private final String tag;
+        private final String value;
+
+        public TaggedValue(String tag, String value) {
+            this.tag = tag;
+            this.value = value;
+        }
+
+        public String getTag() {
+            return tag;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Custom Representer to output TaggedValue with original tags
+     */
+    public static class TagPreservingRepresenter extends Representer {
+        public TagPreservingRepresenter(DumperOptions options) {
+            super(options);
+            this.representers.put(TaggedValue.class, new RepresentTaggedValue());
+        }
+
+        private class RepresentTaggedValue implements Represent {
+            @Override
+            public Node representData(Object data) {
+                TaggedValue tagged = (TaggedValue) data;
+                Tag tag = new Tag(tagged.getTag());
+                return representScalar(tag, tagged.getValue());
+            }
         }
     }
 }

--- a/src/main/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessor.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessor.java
@@ -210,7 +210,8 @@ public class YamlAsciiDocProcessor {
         options.setIndent(2);
         options.setWidth(Integer.MAX_VALUE); // Prevent line wrapping
 
-        Yaml yaml = new Yaml(options);
+        // Use custom representer to preserve unknown tags in output
+        Yaml yaml = new Yaml(new AsciiDocTag.TagPreservingRepresenter(options), options);
         return yaml.dump(data);
     }
 }

--- a/src/test/java/com/dataliquid/maven/asciidoc/mojo/RenderMojoTest.java
+++ b/src/test/java/com/dataliquid/maven/asciidoc/mojo/RenderMojoTest.java
@@ -769,4 +769,26 @@ class RenderMojoTest extends AbstractMojoTest<RenderMojo> {
         String actualOutput = loadFile(generatedFile);
         assertEquals(expectedOutput, actualOutput, "Generated output should match expected YAML");
     }
+
+    @Test
+    void shouldProcessYamlFileWithUnknownTags() throws Exception {
+        // given
+        File testSourceDir = new File(getClass().getResource("/functional/render/yaml-unknown-tags-test").toURI());
+        setField(mojo, "sourceDirectory", testSourceDir);
+
+        String[] includes = new String[] { "**/*.yaml" };
+        setField(mojo, "includes", includes);
+
+        String expectedOutput = loadTestResource("/functional/render/yaml-unknown-tags-test/expected.yaml");
+
+        // when
+        mojo.execute();
+
+        // then
+        File generatedFile = new File(outputDir, "input.yaml");
+        assertTrue(generatedFile.exists(), "Output file should be generated");
+
+        String actualOutput = loadFile(generatedFile);
+        assertEquals(expectedOutput, actualOutput, "Generated output should preserve unknown tags");
+    }
 }

--- a/src/test/resources/functional/render/yaml-unknown-tags-test/expected.yaml
+++ b/src/test/resources/functional/render/yaml-unknown-tags-test/expected.yaml
@@ -1,0 +1,10 @@
+template: !html:template '<div class="wrapper"><p>Content</p></div>'
+content: |-
+  <div class="sect1">
+  <h2 id="_test_document">Test Document</h2>
+  <div class="sectionbody">
+  <div class="paragraph">
+  <p>This is a test.</p>
+  </div>
+  </div>
+  </div>

--- a/src/test/resources/functional/render/yaml-unknown-tags-test/input.yaml
+++ b/src/test/resources/functional/render/yaml-unknown-tags-test/input.yaml
@@ -1,0 +1,5 @@
+template: !html:template "<div class=\"wrapper\"><p>Content</p></div>"
+content: !asciidoc |
+  == Test Document
+
+  This is a test.


### PR DESCRIPTION
## Summary
Implements support for pass-through of unknown YAML tags (e.g., `!html:template`, `!custom:meta`) when processing YAML files with AsciiDoc content.

## Changes
- **AsciiDocTag.java**: Added `TaggedValue` wrapper class and `TagPreservingRepresenter` to preserve unknown YAML tags in output
- **YamlAsciiDocProcessor.java**: Always use custom representer to preserve unknown tags  
- **RenderMojoTest.java**: Added E2E test `shouldProcessYamlFileWithUnknownTags()`
- **Test resources**: Added `yaml-unknown-tags-test/` with input/expected files

## Behavior
- Unknown YAML tags no longer throw `ConstructorException`
- Tags are preserved in output (e.g., `!html:template '<div>...'`)
- `!asciidoc` content is still rendered to HTML
- No configuration required - works automatically

## Example
**Input:**
```yaml
template: !html:template "<div class=\"wrapper\"><p>Content</p></div>"
content: !asciidoc |
  == Test Document
  This is a test.
```

**Output:**
```yaml
template: !html:template '<div class="wrapper"><p>Content</p></div>'
content: |-
  <div class="sect1">
  <h2 id="_test_document">Test Document</h2>
  <div class="sectionbody">
  <div class="paragraph">
  <p>This is a test.</p>
  </div>
  </div>
  </div>
```

## Test Plan
- [x] All existing tests pass (102/102)
- [x] New E2E test verifies unknown tags are preserved
- [x] Verified unknown tags don't throw exceptions
- [x] Verified !asciidoc content is still rendered
- [x] Build successful

Closes #48