### PR TITLE
#50 Support configurable YAML tag mapping

### DIFF
--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/RenderMojo.java
@@ -60,6 +60,9 @@ public class RenderMojo extends AbstractAsciiDocMojo {
     @Parameter(property = "asciidoc.outputFormat", defaultValue = "html")
     private String outputFormat;
 
+    @Parameter(property = "asciidoc.yamlTagMappings")
+    private Map<String, String> yamlTagMappings;
+
     @Override
     protected String getMojoName() {
         return "AsciiDoc processing";
@@ -168,7 +171,8 @@ public class RenderMojo extends AbstractAsciiDocMojo {
     private String processYamlFile(Path yamlFile) throws IOException, MojoExecutionException {
         getLog().info("Processing YAML file with AsciiDoc content: " + yamlFile);
         Options options = createAsciidoctorOptions();
-        YamlAsciiDocProcessor yamlProcessor = new YamlAsciiDocProcessor(getAsciidoctor(), options, getLog());
+        YamlAsciiDocProcessor yamlProcessor = new YamlAsciiDocProcessor(getAsciidoctor(), options, getLog(),
+                yamlTagMappings);
         return yamlProcessor.processYamlFile(yamlFile);
     }
 

--- a/src/main/java/com/dataliquid/maven/asciidoc/yaml/AsciiDocTag.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/yaml/AsciiDocTag.java
@@ -10,15 +10,24 @@ import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Represent;
 import org.yaml.snakeyaml.representer.Representer;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Custom YAML constructor for handling !asciidoc tags
  */
 public class AsciiDocTag extends Constructor {
 
     public static final Tag ASCIIDOC_TAG = new Tag("!asciidoc");
+    private final Map<String, String> tagMappings;
 
     public AsciiDocTag() {
+        this(null);
+    }
+
+    public AsciiDocTag(Map<String, String> tagMappings) {
         super(new LoaderOptions());
+        this.tagMappings = tagMappings != null ? tagMappings : Collections.emptyMap();
         this.yamlConstructors.put(ASCIIDOC_TAG, new ConstructAsciiDoc());
         // Always register fallback constructor for unknown tags
         this.yamlMultiConstructors.put("", new ConstructUnknownTag());
@@ -106,17 +115,50 @@ public class AsciiDocTag extends Constructor {
      * Custom Representer to output TaggedValue with original tags
      */
     public static class TagPreservingRepresenter extends Representer {
+        private final Map<String, String> tagMappings;
+
         public TagPreservingRepresenter(DumperOptions options) {
+            this(options, null);
+        }
+
+        public TagPreservingRepresenter(DumperOptions options, Map<String, String> tagMappings) {
             super(options);
+            this.tagMappings = tagMappings != null ? tagMappings : Collections.emptyMap();
             this.representers.put(TaggedValue.class, new RepresentTaggedValue());
+            this.representers.put(AsciiDocContent.class, new RepresentAsciiDocContent());
         }
 
         private class RepresentTaggedValue implements Represent {
             @Override
             public Node representData(Object data) {
                 TaggedValue tagged = (TaggedValue) data;
-                Tag tag = new Tag(tagged.getTag());
+                String inputTag = tagged.getTag().substring(1); // Remove "!"
+                String outputTag = tagMappings.getOrDefault(inputTag, inputTag);
+                Tag tag = new Tag("!" + outputTag);
                 return representScalar(tag, tagged.getValue());
+            }
+        }
+
+        private class RepresentAsciiDocContent implements Represent {
+            @Override
+            public Node representData(Object data) {
+                AsciiDocContent content = (AsciiDocContent) data;
+                String rendered = content.getRendered() != null ? content.getRendered() : content.getContent();
+
+                // Use literal block style for multiline strings
+                DumperOptions.ScalarStyle style = rendered.contains("\n") ? DumperOptions.ScalarStyle.LITERAL
+                        : DumperOptions.ScalarStyle.PLAIN;
+
+                // Only output tag if mapping is configured
+                if (tagMappings.isEmpty() || !tagMappings.containsKey("asciidoc")) {
+                    // No mapping - return plain string (backward compatible)
+                    return representScalar(Tag.STR, rendered, style);
+                } else {
+                    // With mapping - return with mapped tag
+                    String outputTag = tagMappings.get("asciidoc");
+                    Tag tag = new Tag("!" + outputTag);
+                    return representScalar(tag, rendered, style);
+                }
             }
         }
     }

--- a/src/main/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessor.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/yaml/YamlAsciiDocProcessor.java
@@ -21,14 +21,24 @@ public class YamlAsciiDocProcessor {
     private final Asciidoctor asciidoctor;
     private final Log log;
     private final Options asciidoctorOptions;
+    private final Map<String, String> yamlTagMappings;
 
     /**
      * Constructor for full YAML processing with rendering support
      */
     public YamlAsciiDocProcessor(Asciidoctor asciidoctor, Options asciidoctorOptions, Log log) {
+        this(asciidoctor, asciidoctorOptions, log, null);
+    }
+
+    /**
+     * Constructor for full YAML processing with rendering support and tag mapping
+     */
+    public YamlAsciiDocProcessor(Asciidoctor asciidoctor, Options asciidoctorOptions, Log log,
+            Map<String, String> yamlTagMappings) {
         this.asciidoctor = asciidoctor;
         this.asciidoctorOptions = asciidoctorOptions;
         this.log = log;
+        this.yamlTagMappings = yamlTagMappings;
     }
 
     /**
@@ -39,6 +49,7 @@ public class YamlAsciiDocProcessor {
         this.asciidoctor = null;
         this.asciidoctorOptions = null;
         this.log = log;
+        this.yamlTagMappings = null;
     }
 
     /**
@@ -74,7 +85,7 @@ public class YamlAsciiDocProcessor {
         String content = Files.readString(yamlFile);
 
         // Parse YAML with custom constructor
-        AsciiDocTag constructor = new AsciiDocTag();
+        AsciiDocTag constructor = new AsciiDocTag(yamlTagMappings);
         Yaml yaml = new Yaml(constructor);
         Object data = yaml.load(content);
 
@@ -133,7 +144,7 @@ public class YamlAsciiDocProcessor {
         String content = Files.readString(yamlFile);
 
         // Parse YAML with custom constructor
-        AsciiDocTag constructor = new AsciiDocTag();
+        AsciiDocTag constructor = new AsciiDocTag(yamlTagMappings);
         Yaml yaml = new Yaml(constructor);
         Object data = yaml.load(content);
 
@@ -162,8 +173,6 @@ public class YamlAsciiDocProcessor {
                     AsciiDocTag.AsciiDocContent asciiDocContent = (AsciiDocTag.AsciiDocContent) value;
                     String rendered = renderAsciiDoc(asciiDocContent.getContent());
                     asciiDocContent.setRendered(rendered);
-                    // Replace the AsciiDocContent with rendered HTML
-                    entry.setValue(rendered);
                 } else {
                     traverseAndRender(value);
                 }
@@ -176,8 +185,6 @@ public class YamlAsciiDocProcessor {
                     AsciiDocTag.AsciiDocContent asciiDocContent = (AsciiDocTag.AsciiDocContent) item;
                     String rendered = renderAsciiDoc(asciiDocContent.getContent());
                     asciiDocContent.setRendered(rendered);
-                    // Replace the AsciiDocContent with rendered HTML
-                    list.set(i, rendered);
                 } else {
                     traverseAndRender(item);
                 }
@@ -211,7 +218,7 @@ public class YamlAsciiDocProcessor {
         options.setWidth(Integer.MAX_VALUE); // Prevent line wrapping
 
         // Use custom representer to preserve unknown tags in output
-        Yaml yaml = new Yaml(new AsciiDocTag.TagPreservingRepresenter(options), options);
+        Yaml yaml = new Yaml(new AsciiDocTag.TagPreservingRepresenter(options, yamlTagMappings), options);
         return yaml.dump(data);
     }
 }

--- a/src/test/java/com/dataliquid/maven/asciidoc/mojo/RenderMojoTest.java
+++ b/src/test/java/com/dataliquid/maven/asciidoc/mojo/RenderMojoTest.java
@@ -791,4 +791,30 @@ class RenderMojoTest extends AbstractMojoTest<RenderMojo> {
         String actualOutput = loadFile(generatedFile);
         assertEquals(expectedOutput, actualOutput, "Generated output should preserve unknown tags");
     }
+
+    @Test
+    void shouldProcessYamlFileWithTagMapping() throws Exception {
+        // given
+        File testSourceDir = new File(getClass().getResource("/functional/render/yaml-tag-mapping-test").toURI());
+        setField(mojo, "sourceDirectory", testSourceDir);
+
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put("asciidoc", "html");
+        setField(mojo, "yamlTagMappings", mappings);
+
+        String[] includes = new String[] { "**/*.yaml" };
+        setField(mojo, "includes", includes);
+
+        String expectedOutput = loadTestResource("/functional/render/yaml-tag-mapping-test/expected.yaml");
+
+        // when
+        mojo.execute();
+
+        // then
+        File generatedFile = new File(outputDir, "input.yaml");
+        assertTrue(generatedFile.exists(), "Output file should be generated");
+
+        String actualOutput = loadFile(generatedFile);
+        assertEquals(expectedOutput, actualOutput, "Generated output should map tags");
+    }
 }

--- a/src/test/resources/functional/render/yaml-tag-mapping-test/expected.yaml
+++ b/src/test/resources/functional/render/yaml-tag-mapping-test/expected.yaml
@@ -1,0 +1,6 @@
+document:
+  title: Tag Mapping Test
+  content: !html |-
+    <div class="paragraph">
+    <p>This is a test with tag mapping.</p>
+    </div>

--- a/src/test/resources/functional/render/yaml-tag-mapping-test/input.yaml
+++ b/src/test/resources/functional/render/yaml-tag-mapping-test/input.yaml
@@ -1,0 +1,4 @@
+document:
+  title: "Tag Mapping Test"
+  content: !asciidoc |
+    This is a test with tag mapping.


### PR DESCRIPTION
## Summary
- Add `yamlTagMappings` parameter to RenderMojo for configurable YAML tag mapping
- Extend TagPreservingRepresenter to support AsciiDoc content tag mapping
- Fix rendering bug: preserve AsciiDocContent objects for tag mapping

## Changes
- **RenderMojo.java**: Added yamlTagMappings parameter
- **AsciiDocTag.java**: Added RepresentAsciiDocContent for tag mapping support
- **YamlAsciiDocProcessor.java**: Pass tag mappings to constructor/representer, fixed rendering bug
- **RenderMojoTest.java**: Added shouldProcessYamlFileWithTagMapping test

## Test Plan
- [x] All 103 tests pass
- [x] New test verifies tag mapping (input: !asciidoc → output: !html)
- [x] Existing tests verify backward compatibility (no tag mapping → no tags in output)
- [x] Unknown tag pass-through still works