### PR TITLE
Upgrade to Jackson 3.0.3 and json-schema-validator 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.0</version>
+            <version>3.0.0</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <asciidoctorj.diagram.version>3.1.0</asciidoctorj.diagram.version>
         <asciidoctorj.diagram.plantuml.version>1.2025.3</asciidoctorj.diagram.plantuml.version>
         <asciidoctorj.diagram.ditaamini.version>1.0.3</asciidoctorj.diagram.ditaamini.version>
-        <jackson.version>2.20.1</jackson.version>
+        <jackson.version>3.0.3</jackson.version>
         <maven.plugin.tools.version>3.15.2</maven.plugin.tools.version>
     </properties>
 
@@ -85,13 +85,13 @@
         </dependency>
         
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        
+
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>com.dataliquid</groupId>
             <artifactId>asciidoc-linter</artifactId>
-            <version>0.6.0</version>
+            <version>0.7.0</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/LinterMojo.java
@@ -129,24 +129,14 @@ public class LinterMojo extends AbstractAsciiDocMojo {
         SummaryConfig summaryConfig = baseConfig.getSummary();
         boolean showLineNumbers = baseConfig.getDisplay().isShowLineNumbers();
 
-        return OutputConfiguration
-                .builder()
-                .display(DisplayConfig
-                        .builder()
-                        .contextLines(contextLines)
-                        .highlightStyle(highlightErrors ? HighlightStyle.UNDERLINE : HighlightStyle.NONE)
-                        .useColors(useColors && MavenLogWriter.supportsAnsiColors())
-                        .showLineNumbers(showLineNumbers)
-                        .showHeader(false)
-                        .build())
-                .suggestions(SuggestionsConfig
-                        .builder()
-                        .enabled(showSuggestions)
-                        .maxPerError(maxSuggestionsPerError)
-                        .showExamples(showExamples)
-                        .build())
-                .summary(summaryConfig)
-                .build();
+        return new OutputConfiguration(null, // format - use default
+                new DisplayConfig(contextLines, highlightErrors ? HighlightStyle.UNDERLINE : HighlightStyle.NONE,
+                        useColors && MavenLogWriter.supportsAnsiColors(), showLineNumbers, null, // maxLineWidth - use
+                                                                                                 // default
+                        false // showHeader
+                ), new SuggestionsConfig(showSuggestions, maxSuggestionsPerError, showExamples), null, // errorGrouping
+                                                                                                       // - use default
+                summaryConfig);
     }
 
     /**

--- a/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/mojo/ValidateMojo.java
@@ -24,9 +24,10 @@ import org.asciidoctor.ast.Document;
 
 import com.dataliquid.maven.asciidoc.model.ValidationError;
 import com.dataliquid.maven.asciidoc.util.MetadataCollector;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.Schema;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.SpecificationVersion;
 
@@ -52,7 +53,7 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
     @Parameter(property = "asciidoc.metadataExportFile")
     private File metadataExportFile;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = new JsonMapper();
     private final MetadataCollector metadataCollector = new MetadataCollector();
 
     @Override
@@ -77,9 +78,7 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
                 // Log collected metadata in debug mode
                 if (getLog().isDebugEnabled()) {
                     try {
-                        String prettyJson = objectMapper
-                                .writerWithDefaultPrettyPrinter()
-                                .writeValueAsString(allMetadata);
+                        String prettyJson = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(allMetadata);
                         getLog().debug("Collected metadata for " + relativePath + ":\n" + prettyJson);
                     } catch (Exception e) {
                         getLog().debug("Failed to serialize metadata for logging: " + e.getMessage());
@@ -127,7 +126,7 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
 
             // Load schema from file
             String schemaContent = Files.readString(schemaFileToLoad.toPath());
-            JsonNode schemaNode = objectMapper.readTree(schemaContent);
+            JsonNode schemaNode = jsonMapper.readTree(schemaContent);
 
             return registry.getSchema(schemaNode);
 
@@ -228,7 +227,7 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
 
             // Convert metadata to JSON
             Map<String, Object> metadataJson = metadataCollector.toJson();
-            JsonNode metadataNode = objectMapper.valueToTree(metadataJson);
+            JsonNode metadataNode = jsonMapper.valueToTree(metadataJson);
 
             // Validate against schema - returns List<Error> in 2.0.0
             List<com.networknt.schema.Error> validationErrors = schema.validate(metadataNode);
@@ -263,7 +262,7 @@ public class ValidateMojo extends AbstractAsciiDocMojo {
         Map<String, Object> metadataJson = metadataCollector.toJson();
 
         // Write pretty-printed JSON to file
-        String jsonOutput = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(metadataJson);
+        String jsonOutput = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(metadataJson);
 
         Files.writeString(metadataExportFile.toPath(), jsonOutput);
 

--- a/src/main/java/com/dataliquid/maven/asciidoc/parser/FrontMatterParser.java
+++ b/src/main/java/com/dataliquid/maven/asciidoc/parser/FrontMatterParser.java
@@ -6,15 +6,15 @@ import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 @SuppressWarnings("PMD.GuardLogStatement")
 public class FrontMatterParser {
 
-    private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-    private final ObjectMapper jsonMapper = new ObjectMapper();
+    private final YAMLMapper yamlMapper = new YAMLMapper();
+    private final JsonMapper jsonMapper = new JsonMapper();
     private final Log log;
 
     public FrontMatterParser() {


### PR DESCRIPTION
## Summary
- Upgrade Jackson from 2.20.1 to 3.0.3
- Upgrade json-schema-validator from 2.0.0 to 3.0.0 (via asciidoc-linter)
- Upgrade asciidoc-linter from 0.6.0 to 0.7.0
- Migrate package imports from `com.fasterxml.jackson` to `tools.jackson`
- Adapt to new asciidoc-linter API (constructor-based instead of builder pattern)

## Changes
- **pom.xml**: Updated Jackson version, groupIds, and asciidoc-linter version
- **ValidateMojo.java**: Migrated to `JsonMapper` and `tools.jackson` imports
- **FrontMatterParser.java**: Migrated to `YAMLMapper`/`JsonMapper`
- **LinterMojo.java**: Adapted to new OutputConfiguration API (constructors instead of builders)

## Test plan
- [x] All 103 tests pass
- [x] Build completes successfully
- [x] Manual verification of plugin functionality